### PR TITLE
Add site scraping for new articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 A small proof-of-concept tool for ingesting threat intel feeds and summarizing articles with an LLM.
 
+The `config.yaml` file lists websites to watch. Each site entry includes a CSS
+selector that identifies article links. The scraper stores seen URLs in a small
+SQLite database so each run only processes unseen articles.
+
 ## Agents
 
-- `summarizer.py` – downloads the latest article from each configured feed and summarizes it with OpenAI.
+- `summarizer.py` – downloads any new articles from the configured sites and summarizes them with OpenAI.
 - `detection_agent.py` – similar to the summarizer but also interprets the article and proposes detection strategies. Pass `--prompt` to experiment with custom system prompts.
 
 Run tests with `pytest`.

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,8 @@
-feeds:
-  - url: https://www.darkreading.com/rss.xml
-    name: Dark Reading
-poll_interval_minutes: 60
+sites:
+  - url: https://thedfirreport.com/
+    name: DFIR Report
+    selector: h2 a
+  - url: https://posts.specterops.io/
+    name: SpecterOps Posts
+    selector: article a
+  poll_interval_minutes: 60

--- a/src/detectobot/agents/detection_agent.py
+++ b/src/detectobot/agents/detection_agent.py
@@ -2,7 +2,7 @@ import os
 import argparse
 import openai
 import time
-from detectobot.agents.feed_watcher import get_latest_article_links
+from detectobot.agents.site_watcher import get_new_article_links
 import requests
 from bs4 import BeautifulSoup
 from readability import Document
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
     assistant = build_assistant(system_prompt)
 
-    for feed in get_latest_article_links():
+    for feed in get_new_article_links():
         name = feed["name"]
         link = feed["link"]
         print(f"\n=== Feed: {name} ===")

--- a/src/detectobot/agents/site_watcher.py
+++ b/src/detectobot/agents/site_watcher.py
@@ -1,0 +1,66 @@
+import os
+import yaml
+import sqlite3
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+from detectobot import feed_watcher as core
+
+CONFIG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../config.yaml'))
+DB_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../site_watcher.db'))
+
+
+def load_config():
+    """Load site configuration from YAML file."""
+    with open(CONFIG_PATH, 'r') as f:
+        cfg = yaml.safe_load(f)
+    sites = []
+    for site in cfg.get('sites', []):
+        name = site.get('name')
+        url = site.get('url')
+        selector = site.get('selector', 'a')
+        if name and url:
+            sites.append((name, url, selector))
+    return sites
+
+
+def get_new_article_links(db_path: str = DB_PATH):
+    """Return unseen article links from configured websites."""
+    sites = load_config()
+    conn = sqlite3.connect(db_path)
+    core.init_db(conn)
+    new_links = []
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        )
+    }
+
+    for name, url, selector in sites:
+        try:
+            resp = requests.get(url, headers=headers, timeout=10)
+            resp.raise_for_status()
+        except Exception:
+            continue
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        for a in soup.select(selector):
+            link = a.get('href')
+            if not link:
+                continue
+            abs_link = urljoin(url, link)
+            entry = {'link': abs_link}
+            h = core.entry_hash(entry)
+            if core.check_and_store(conn, h, name, entry):
+                new_links.append({'name': name, 'link': abs_link})
+
+    conn.close()
+    return new_links
+
+
+if __name__ == '__main__':
+    for item in get_new_article_links():
+        print(f"--- {item['name']} ---\n- {item['link']}\n")

--- a/src/detectobot/agents/summarizer.py
+++ b/src/detectobot/agents/summarizer.py
@@ -2,7 +2,7 @@ import os
 import argparse
 import openai
 import time
-from detectobot.agents.feed_watcher import get_latest_article_links
+from detectobot.agents.site_watcher import get_new_article_links
 import requests
 from bs4 import BeautifulSoup
 from readability import Document
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     parser.add_argument('--dry-run', action='store_true', help='Preview without API call')
     args = parser.parse_args()
 
-    for feed in get_latest_article_links():
+    for feed in get_new_article_links():
         name = feed['name']
         link = feed['link']
         print(f"\n=== Feed: {name} ===")

--- a/tests/test_site_watcher.py
+++ b/tests/test_site_watcher.py
@@ -1,0 +1,108 @@
+import sys
+import sqlite3
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# Provide simple stubs for requests and yaml
+requests_stub = types.ModuleType("requests")
+
+def _fake_get(url, headers=None, timeout=10):
+    class Resp:
+        def __init__(self, text):
+            self.text = text
+        def raise_for_status(self):
+            pass
+    return Resp(_fake_get.html)
+
+requests_stub.get = _fake_get
+sys.modules["requests"] = requests_stub
+
+bs4_stub = types.ModuleType("bs4")
+
+class _Tag:
+    def __init__(self, href):
+        self._href = href
+
+    def get(self, attr):
+        return self._href if attr == "href" else None
+
+
+class BeautifulSoup:
+    def __init__(self, html, parser):
+        import re
+        self._links = re.findall(r"href=['\"]([^'\"]+)['\"]", html)
+
+    def select(self, selector):
+        return [_Tag(h) for h in self._links]
+
+bs4_stub.BeautifulSoup = BeautifulSoup
+sys.modules["bs4"] = bs4_stub
+
+yaml_stub = types.ModuleType("yaml")
+
+def _yaml_load(stream):
+    text = stream.read() if hasattr(stream, "read") else stream
+    lines = [line.rstrip() for line in text.splitlines()]
+    sites = []
+    current = None
+    for line in lines:
+        if line.startswith("sites:"):
+            continue
+        if line.startswith("  - "):
+            if current:
+                sites.append(current)
+            current = {}
+            remainder = line[4:]
+            if remainder:
+                key, value = remainder.split(":", 1)
+                current[key.strip()] = value.strip()
+        elif line.startswith("    "):
+            key, value = line.strip().split(":", 1)
+            current[key.strip()] = value.strip()
+    if current:
+        sites.append(current)
+    return {"sites": sites}
+
+yaml_stub.safe_load = _yaml_load
+sys.modules["yaml"] = yaml_stub
+
+from detectobot import feed_watcher
+from detectobot.agents import site_watcher
+
+entry_hash = feed_watcher.entry_hash
+check_and_store = feed_watcher.check_and_store
+init_db = feed_watcher.init_db
+
+
+def test_load_config(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        "sites:\n  - name: Example\n    url: http://example.com\n    selector: a\n"
+    )
+    monkeypatch.setattr(site_watcher, "CONFIG_PATH", str(cfg))
+    sites = site_watcher.load_config()
+    assert sites == [("Example", "http://example.com", "a")]
+
+
+def test_get_new_article_links(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        "sites:\n  - name: Example\n    url: http://example.com\n    selector: a\n"
+    )
+    monkeypatch.setattr(site_watcher, "CONFIG_PATH", str(cfg))
+
+    html = "<html><body><a href='p1'>1</a><a href='p2'>2</a></body></html>"
+    _fake_get.html = html
+
+    db_path = tmp_path / "db.sqlite"
+    links = site_watcher.get_new_article_links(db_path=str(db_path))
+    assert links == [
+        {"name": "Example", "link": "http://example.com/p1"},
+        {"name": "Example", "link": "http://example.com/p2"},
+    ]
+
+    # second call should return empty
+    links = site_watcher.get_new_article_links(db_path=str(db_path))
+    assert links == []


### PR DESCRIPTION
## Summary
- switch config to list websites to scrape for article links
- add `site_watcher` module that tracks new links via BeautifulSoup
- update agents to use the new watcher
- document website scraping behaviour
- add tests covering the site watcher

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68563936f88083228de53afa91c2508d