### PR TITLE
Improve summarizer agent and add watcher helpers

### DIFF
--- a/src/detectobot/__init__.py
+++ b/src/detectobot/__init__.py
@@ -1,1 +1,4 @@
-# detectabot package
+"""detectobot package"""
+from . import feed_watcher
+
+__all__ = ["feed_watcher"]

--- a/src/detectobot/agents/feed_watcher.py
+++ b/src/detectobot/agents/feed_watcher.py
@@ -1,0 +1,71 @@
+"""Feed watcher utilities used by agents."""
+import os
+import sqlite3
+import feedparser
+from typing import List, Tuple, Dict
+
+from ..core.db_utils import init_db, entry_hash, check_and_store, DB_PATH
+
+# Path to configuration file; can be overridden in tests
+CONFIG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../config.yaml'))
+
+
+def load_config(config_path: str | None = None) -> List[Tuple[str, str]]:
+    """Return list of (name, url) tuples from the feeds section."""
+    if config_path is None:
+        config_path = CONFIG_PATH
+    with open(config_path, "r") as f:
+        text = f.read()
+    feeds = []
+    current = None
+    for line in text.splitlines():
+        line = line.rstrip()
+        if line.startswith("feeds:"):
+            continue
+        if line.startswith("  - "):
+            if current:
+                feeds.append(current)
+            current = {}
+            remainder = line[4:]
+            if remainder:
+                key, value = remainder.split(":", 1)
+                current[key.strip()] = value.strip()
+        elif line.startswith("    "):
+            key, value = line.strip().split(":", 1)
+            current[key.strip()] = value.strip()
+    if current:
+        feeds.append(current)
+    return [(f.get("name"), f.get("url")) for f in feeds]
+
+
+def get_latest_article_links(config_path: str | None = None) -> List[Dict[str, str]]:
+    """Return the latest article link from each configured feed."""
+    feeds = load_config(config_path) if config_path is not None else load_config()
+    links: List[Dict[str, str]] = []
+    for name, url in feeds:
+        parsed = feedparser.parse(url)
+        entries = getattr(parsed, 'entries', [])
+        if entries:
+            link = entries[0].get('link')
+            if link:
+                links.append({'name': name, 'link': link})
+    return links
+
+
+def get_new_article_links(db_path: str = DB_PATH, config_path: str | None = None) -> List[Dict[str, str]]:
+    """Return unseen article links from all configured feeds."""
+    conn = sqlite3.connect(db_path)
+    init_db(conn)
+    new_links: List[Dict[str, str]] = []
+    feeds = load_config(config_path) if config_path is not None else load_config()
+    for name, url in feeds:
+        parsed = feedparser.parse(url)
+        for entry in getattr(parsed, 'entries', []):
+            h = entry_hash(entry)
+            if check_and_store(conn, h, name, entry):
+                link = entry.get('link')
+                if link:
+                    new_links.append({'name': name, 'link': link})
+    conn.close()
+    return new_links
+

--- a/src/detectobot/agents/site_watcher.py
+++ b/src/detectobot/agents/site_watcher.py
@@ -1,0 +1,51 @@
+"""Website watcher utilities used by agents."""
+import os
+import sqlite3
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+from typing import List, Tuple, Dict
+
+
+from ..core.db_utils import init_db, entry_hash, check_and_store, DB_PATH
+
+CONFIG_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../config.yaml'))
+
+
+def load_config(config_path: str | None = None) -> List[Tuple[str, str, str]]:
+    """Return list of (name, url, selector) tuples from the sites section."""
+    if config_path is None:
+        config_path = CONFIG_PATH
+    with open(config_path, "r") as f:
+        import yaml
+        cfg = yaml.safe_load(f)
+    sites = cfg.get('sites', [])
+    return [(s['name'], s['url'], s.get('selector', 'a')) for s in sites]
+
+
+def get_new_article_links(db_path: str = DB_PATH, config_path: str | None = None) -> List[Dict[str, str]]:
+    """Return unseen article links from configured websites."""
+    conn = sqlite3.connect(db_path)
+    init_db(conn)
+    new_links: List[Dict[str, str]] = []
+    headers = {"User-Agent": "Mozilla/5.0"}
+    sites = load_config(config_path) if config_path is not None else load_config()
+    for name, url, selector in sites:
+        try:
+            resp = requests.get(url, headers=headers, timeout=10)
+            resp.raise_for_status()
+        except Exception:
+            continue
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        for a in soup.select(selector):
+            link = a.get('href')
+            if not link:
+                continue
+            abs_link = urljoin(url, link)
+            entry = {'link': abs_link}
+            h = entry_hash(entry)
+            if check_and_store(conn, h, name, entry):
+                new_links.append({'name': name, 'link': abs_link})
+    conn.close()
+    return new_links
+

--- a/src/detectobot/feed_watcher.py
+++ b/src/detectobot/feed_watcher.py
@@ -1,0 +1,4 @@
+"""Wrapper module exposing database helpers for tests."""
+from .core.db_utils import entry_hash, init_db, check_and_store
+
+__all__ = ["entry_hash", "init_db", "check_and_store"]


### PR DESCRIPTION
## Summary
- rewrite `summarizer.py` to use pydantic-ai and produce detection tips
- add feed and site watcher helper modules for tests
- expose `feed_watcher` from package root
- implement simple config parser in watcher helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fc7ee6b48322b4429840f91cd046